### PR TITLE
Use typescript 2.1.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "sinon-chai": "^2.8.0",
     "source-map-support": "^0.4.0",
     "tslint": "^3.11.0",
-    "typescript": "^1.8.10",
+    "typescript": "~2.1.0",
     "typings": "^1.2.0",
     "validate-commit-msg": "^2.3.1",
     "watch": "^0.18.0",

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -292,13 +292,14 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
   private setupEvents(xhr: XMLHttpRequest, request: AjaxRequest) {
     const progressSubscriber = request.progressSubscriber;
 
-    xhr.ontimeout = function xhrTimeout(e) {
+    function xhrTimeout(this: XMLHttpRequest, e: ProgressEvent) {
       const {subscriber, progressSubscriber, request } = (<any>xhrTimeout);
       if (progressSubscriber) {
         progressSubscriber.error(e);
       }
       subscriber.error(new AjaxTimeoutError(this, request)); //TODO: Make betterer.
     };
+    xhr.ontimeout = xhrTimeout;
     (<any>xhr.ontimeout).request = request;
     (<any>xhr.ontimeout).subscriber = this;
     (<any>xhr.ontimeout).progressSubscriber = progressSubscriber;
@@ -311,14 +312,15 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
         };
         (<any>xhr.onprogress).progressSubscriber = progressSubscriber;
       }
-
-      xhr.onerror = function xhrError(e) {
+      let xhrError: (e: ErrorEvent) => void;
+      xhrError = function(this: XMLHttpRequest, e: ErrorEvent) {
         const { progressSubscriber, subscriber, request } = (<any>xhrError);
         if (progressSubscriber) {
           progressSubscriber.error(e);
         }
         subscriber.error(new AjaxError('ajax error', this, request));
       };
+      xhr.onerror = xhrError;
       (<any>xhr.onerror).request = request;
       (<any>xhr.onerror).subscriber = this;
       (<any>xhr.onerror).progressSubscriber = progressSubscriber;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "removeComments": false,
     "preserveConstEnums": true,
-    "sourceMap": true,
     "declaration": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
…e that breaks tsickle

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
